### PR TITLE
fix: include build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ To install dependencies for all projects, simply run:
 npx lerna bootstrap
 ```
 
+To build all packages, just run:
+
+```
+npx lerna build
+```
+
 You can then run Storybook by running:
 
 ```


### PR DESCRIPTION
When trying to set up the environment for the first time, `npx lerna run storybook` will run into "Module not found" error. I discovered you need to build all the packages first.